### PR TITLE
keep existing git history when cloning repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,5 @@ gitmodules: initialize
 	@make prepare
 
 initialize:
-	@test -f .prepared || rm -rf .git .gitmodules meta
+	@test -f .prepared || ( git log | grep "Update meta" || rm -rf .git .gitmodules meta )
 	@test -f .prepared || ( cd $(base) && ( test -d .git || git init ) )


### PR DESCRIPTION
When cloning a repository to a new location the history was deleted, forcing to use `-allow-unrelated-histories`. To avoid this, I propose to clean the history only als long as there is no initialization commit. Thereby, the development history is cleaned, but once a thesis is started, its history is kept.

Upon writing this, I am unsure whether searching `git log` or commiting the .prepared marker file is cleaner